### PR TITLE
Implement contact type for switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Simple polling input debounce [Arduino](https://www.arduino.cc/) library. Also u
     - external pull-down resistor
     - external pull-up resistor
     - internal pull-up resistor (default)
+ - handles switches with:
+    - Normally Open
+    - Normally Closed
 
 Available from the Arduino IDE [Library Manager](https://www.arduino.cc/en/Guide/Libraries) and for PlatformIO as [library](http://platformio.org/lib/show/123/InputDebounce) (Id #123).
 

--- a/examples/Test_InputDebounce_Normally_Closed/Test_InputDebounce_Normally_Closed.ino
+++ b/examples/Test_InputDebounce_Normally_Closed/Test_InputDebounce_Normally_Closed.ino
@@ -1,0 +1,93 @@
+/*
+  Test InputDebounce Arduino Library
+
+  Mario Ban, 05.2015
+  https://github.com/Mokolea/InputDebounce
+
+
+  Copyright 2017 Mario Ban
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "InputDebounce.h"
+
+#define BUTTON_DEBOUNCE_DELAY   20   // [ms]
+
+static const int pinLED = LED_BUILTIN; // 13
+static const int pinSwitch = 2;
+
+static InputDebounce buttonTest; // not enabled yet, setup has to be called later
+
+void setup()
+{
+  // initialize digital pin as an output
+  pinMode(pinLED, OUTPUT);
+  
+  // init serial
+  Serial.begin(9600);
+  
+  Serial.println("Test InputDebounce library");
+  
+  // setup input button as Normally closed
+  buttonTest.setup(pinSwitch, BUTTON_DEBOUNCE_DELAY, InputDebounce::PIM_INT_PULL_UP_RES,0,InputDebounce::NC);
+  
+  // examples
+  // buttonTest.setup(pinSwitch);
+  // buttonTest.setup(pinSwitch, DEFAULT_INPUT_DEBOUNCE_DELAY);
+  // buttonTest.setup(pinSwitch, BUTTON_DEBOUNCE_DELAY, InputDebounce::PIM_EXT_PULL_UP_RES);
+}
+
+void loop()
+{
+  static unsigned int buttonTest_StateOnCount = 0; // to handle new pressed state, and still pressed state
+  static unsigned int buttonTest_OnTimeLast = 0; // to handle new released state, and remember last on-time (button pressed)
+  
+  unsigned long now = millis();
+  
+  // poll button state, return continuous on-time [ms] if pressed (debounced)
+  unsigned int buttonTest_OnTime = buttonTest.process(now);
+  
+  // handle input button
+  if(buttonTest_OnTime) {
+    // save current on-time (button pressed), to be used when released
+    buttonTest_OnTimeLast = buttonTest_OnTime;
+    // check for state change
+    unsigned int count = buttonTest.getStateOnCount();
+    if(buttonTest_StateOnCount != count) {
+      buttonTest_StateOnCount = count;
+      // handle pressed state
+      digitalWrite(pinLED, HIGH); // turn the LED on
+      Serial.print("HIGH");
+    }
+    else {
+      // handle still pressed state
+      Serial.print("HIGH still pressed");
+    }
+    Serial.print(" (");
+    Serial.print(buttonTest_OnTime);
+    Serial.println("ms)");
+  }
+  else {
+    if(buttonTest_OnTimeLast) {
+      // handle released state
+      digitalWrite(pinLED, LOW); // turn the LED off
+      Serial.print("LOW (last on-time: HIGH ");
+      Serial.print(buttonTest_OnTimeLast);
+      Serial.println("ms)");
+      buttonTest_OnTimeLast = 0; // reset, do not handle this released state again
+    }
+  }
+  
+  delay(1); // [ms]
+}

--- a/src/InputDebounce.cpp
+++ b/src/InputDebounce.cpp
@@ -25,10 +25,11 @@
 //namespace inputdebounce
 //{
 
-InputDebounce::InputDebounce(int8_t pinIn, unsigned long debDelay, PinInMode pinInMode, unsigned long pressedDuration)
+InputDebounce::InputDebounce(int8_t pinIn, unsigned long debDelay, PinInMode pinInMode, unsigned long pressedDuration, SwitchType switchType)
   : _pinIn(0)
   , _debDelay(0)
   , _pinInMode(PIM_INT_PULL_UP_RES)
+  , _switchType(NO)
   , _pressedDuration(0)
   , _enabled(false)
   , _valueLast(false)
@@ -46,18 +47,18 @@ InputDebounce::InputDebounce(int8_t pinIn, unsigned long debDelay, PinInMode pin
 InputDebounce::~InputDebounce()
 {}
 
-void InputDebounce::setup(int8_t pinIn, unsigned long debDelay, PinInMode pinInMode, unsigned long pressedDuration)
+void InputDebounce::setup(int8_t pinIn, unsigned long debDelay, PinInMode pinInMode, unsigned long pressedDuration, SwitchType switchType)
 {
   if(pinIn >= 0) {
     _pinIn = pinIn;
     _debDelay = debDelay;
     _pinInMode = pinInMode;
     _pressedDuration = pressedDuration;
+    _switchType = switchType;
     // initialize digital pin as an input
     if(_pinInMode == PIM_INT_PULL_UP_RES) {
       pinMode(_pinIn, INPUT_PULLUP);
-    }
-    else {
+    } else {
       pinMode(_pinIn, INPUT);
     }
     _enabled = true;
@@ -75,6 +76,10 @@ unsigned long InputDebounce::process(unsigned long now)
   bool value = digitalRead(_pinIn) ? true : false; // LOW (with pull-up res) when button pressed (on)
   // adjust value pressed (on)
   if(_pinInMode != PIM_EXT_PULL_DOWN_RES) {
+    value = !value;
+  }
+  // if NC, invert
+  if(_switchType == NC){
     value = !value;
   }
   // check if input value changed

--- a/src/InputDebounce.cpp
+++ b/src/InputDebounce.cpp
@@ -58,7 +58,8 @@ void InputDebounce::setup(int8_t pinIn, unsigned long debDelay, PinInMode pinInM
     // initialize digital pin as an input
     if(_pinInMode == PIM_INT_PULL_UP_RES) {
       pinMode(_pinIn, INPUT_PULLUP);
-    } else {
+    } 
+    else {
       pinMode(_pinIn, INPUT);
     }
     _enabled = true;

--- a/src/InputDebounce.h
+++ b/src/InputDebounce.h
@@ -39,19 +39,25 @@ public:
   enum PinInMode {
     PIM_EXT_PULL_DOWN_RES,
     PIM_EXT_PULL_UP_RES,
-    PIM_INT_PULL_UP_RES
+    PIM_INT_PULL_UP_RES,
+  };
+  enum SwitchType{
+    NO,
+    NC
   };
   
   InputDebounce(int8_t pinIn = -1, // set input pin >= 0 to enable --> calls setup
                 unsigned long debDelay = DEFAULT_INPUT_DEBOUNCE_DELAY,
                 PinInMode pinInMode = PIM_INT_PULL_UP_RES,
-                unsigned long pressedDuration = 0); // pressed-on time duration: 0 continuous; >0 single-shot [ms]
+                unsigned long pressedDuration = 0,
+                SwitchType switchType = NO); // pressed-on time duration: 0 continuous; >0 single-shot [ms]
   virtual ~InputDebounce();
   
   void setup(int8_t pinIn,
              unsigned long debDelay = DEFAULT_INPUT_DEBOUNCE_DELAY,
              PinInMode pinInMode = PIM_INT_PULL_UP_RES,
-             unsigned long pressedDuration = 0);
+             unsigned long pressedDuration = 0,
+             SwitchType switchType = NO);
   unsigned long process(unsigned long now); // poll button state, returns continuous pressed-on time duration if on (> debounce delay)
   
   uint8_t getPinIn() const;
@@ -72,6 +78,7 @@ private:
   uint8_t _pinIn;
   unsigned long _debDelay;
   PinInMode _pinInMode;
+  SwitchType _switchType;
   unsigned long _pressedDuration;
   
   bool _enabled;


### PR DESCRIPTION
Provides an option to declare the switch contact type, e.g. normally open, or normally closed.